### PR TITLE
Upgrade ansible to 2.2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.0.0
+ansible==2.2.1.0
 awscli==1.11.36
 boto==2.45.0
 botocore==1.4.93


### PR DESCRIPTION
The ec2_elb_facts ansible module is broken in 2.2.0.0 and fixed in
2.2.1.0. Bump the ansible version.