### PR TITLE
move ansible to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.1.0
+ansible==2.2.2.0
 awscli==1.11.36
 boto==2.45.0
 botocore==1.4.93


### PR DESCRIPTION
this resolves a templating error in ansible that was preventing
the Dex chart from instaling