### PR TITLE
bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,11 @@ ENV     K8S_HELM_VERSION=v2.3.1
 
 ENV     K8S_VERSION_1_4=v1.4.12
 ENV     K8S_VERSION_1_5=v1.5.7
-ENV     K8S_VERSION_1_6=v1.6.3
+ENV     K8S_VERSION_1_6=v1.6.4
 
 ENV     K8S_HELM_VERSION_1_4=v2.1.3
 ENV     K8S_HELM_VERSION_1_5=v2.3.1
-# Currently, there is no support for K8s 1.6. Version 2.4.0 will be released May 1, 2017 and will support 1.6.
-#ENV     K8S_HELM_VERSION_1_6=v2.4.1
+ENV     K8S_HELM_VERSION_1_6=v2.4.1
 
 ENV     GOPATH /go
 ENV     GO15VENDOREXPERIMENT 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,17 @@ ENV     CLOUDSDK_PYTHON_SITEPACKAGES 1
         # google cloud kubectl is superceeded by downloaded kubectl
 ENV     PATH $PATH:/google-cloud-sdk/bin
 
-ENV     K8S_VERSION=v1.4.4
+ENV     K8S_VERSION=v1.4.12
 ENV     K8S_HELM_VERSION=v2.3.1
 
-ENV     K8S_VERSION_1_4=v1.4.9
-ENV     K8S_VERSION_1_5=v1.5.4
-ENV     K8S_VERSION_1_6=v1.6.0-beta.4
+ENV     K8S_VERSION_1_4=v1.4.12
+ENV     K8S_VERSION_1_5=v1.5.7
+ENV     K8S_VERSION_1_6=v1.6.3
 
 ENV     K8S_HELM_VERSION_1_4=v2.1.3
 ENV     K8S_HELM_VERSION_1_5=v2.3.1
 # Currently, there is no support for K8s 1.6. Version 2.4.0 will be released May 1, 2017 and will support 1.6.
-#ENV     K8S_HELM_VERSION_1_6=v2.4.0
+#ENV     K8S_HELM_VERSION_1_6=v2.4.1
 
 ENV     GOPATH /go
 ENV     GO15VENDOREXPERIMENT 1


### PR DESCRIPTION
weekly version bump.  leaving the old style k8s version pinned to the 1.4 series.  it should be removed in the next two weeks.