### PR TITLE
Move RUNs to shell script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,84 +31,9 @@ ENV     K8S_HELM_VERSION_LATEST=$K8S_HELM_VERSION_1_6
 ENV     GOPATH /go
 ENV     GO15VENDOREXPERIMENT 1
 
-# Prepping Alpine
 
 ADD     /alpine-builds /alpine-builds
-
-        # Adding baseline alpine packages
-RUN     apk update && apk add --no-cache openssl python bash wget py-pip py-cffi py-cryptography unzip curl zip make go git && \
-    	/alpine-builds/build-docker.sh && rm -rf /alpine-builds
-
-# Python / ansible addon work
 ADD     requirements.txt /requirements.txt
-        # update pip
-RUN     pip install --upgrade pip
-        # install all python packages
-RUN     pip install -r /requirements.txt
+ADD     imagerun.sh /imagerun.sh
 
-# Terraform
-
-        #Installing Terraform binary
-RUN     curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-	    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && mv terraform /usr/bin/
-
-	    # Adding Terraform Provider Execute addon
-RUN     wget https://github.com/samsung-cnct/terraform-provider-execute/releases/download/${TF_PROVIDEREXECUTE_VERSION}/terraform-provider-execute_linux_amd64.tar.gz && \
-        tar -zxvf terraform-provider-execute_linux_amd64.tar.gz && rm terraform-provider-execute_linux_amd64.tar.gz && mv terraform-provider-execute /usr/bin/
-
-	    # Adding Terraform CoreOS Box addon
-RUN 	wget https://github.com/samsung-cnct/terraform-provider-coreosbox/releases/download/${TF_COREOSBOX_VERSION}/terraform-provider-coreosbox_linux_amd64.tar.gz && \
-	    tar -zxvf terraform-provider-coreosbox_linux_amd64.tar.gz && rm terraform-provider-coreosbox_linux_amd64.tar.gz && mv terraform-provider-coreosbox /usr/bin/
-
-	    # Adding Terraform Distro Image Selector addon
-RUN 	wget https://github.com/samsung-cnct/terraform-provider-distroimage/releases/download/${TF_DISTROIMAGE_VERSION}/terraform-provider-distroimage_linux_amd64.tar.gz && \
-	    tar -zxvf terraform-provider-distroimage_linux_amd64.tar.gz && rm terraform-provider-distroimage_linux_amd64.tar.gz && mv terraform-provider-distro /usr/bin/
-
-# AWS work
-
-        # Adding AWS CLI
-RUN     pip install awscli
-
-# Google cloud work
-RUN     wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip && \
-        unzip google-cloud-sdk.zip && \
-        rm google-cloud-sdk.zip
-RUN     google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
-
-
-        # Disable updater check for the whole installation.
-        # Users won't be bugged with notifications to update to the latest version of gcloud.
-RUN     google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
-
-        # Disable updater completely.
-        # Running `gcloud components update` doesn't really do anything in a union FS.
-        # Changes are lost on a subsequent run.
-RUN     sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
-
-        # Adding Kubernetes
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /usr/bin
-
-         # Adding Helm
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz && mv linux-amd64/helm /usr/bin/ && rm -rf linux-amd64 helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
-
-# Kubernetes
-
-        # Creating path for helm and kubectl executables
-RUN     mkdir -p /opt/cnct/kubernetes/v1.4/bin
-RUN     mkdir -p /opt/cnct/kubernetes/v1.5/bin
-RUN     mkdir -p /opt/cnct/kubernetes/v1.6/bin
-RUN     ln -s /opt/cnct/kubernetes/$LATEST /opt/cnct/kubernetes/latest
-
-        # Helm versioning
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz && mv linux-amd64/helm /opt/cnct/kubernetes/v1.4/bin/helm && rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz && mv linux-amd64/helm /opt/cnct/kubernetes/v1.5/bin/helm && rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz && mv linux-amd64/helm /opt/cnct/kubernetes/v1.6/bin/helm && rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz
-
-        # Kubectl versioning
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_4}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /opt/cnct/kubernetes/v1.4/bin
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_5}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /opt/cnct/kubernetes/v1.5/bin
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_6}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /opt/cnct/kubernetes/v1.6/bin
+RUN     /imagerun.sh

--- a/imagerun.sh
+++ b/imagerun.sh
@@ -1,0 +1,89 @@
+#!/bin/sh -e
+set -o pipefail
+
+# Prepping Alpine
+# Adding baseline alpine packages
+apk update 
+apk add --no-cache  \
+    openssl \
+    ca-certificates \
+    python \
+    bash \
+    wget \
+    py-pip \
+    py-cffi \
+    py-cryptography \
+    unzip \
+    zip \
+    python-dev \
+    gcc \
+    linux-headers \
+    musl-dev \
+    g++
+/alpine-builds/build-docker.sh 
+rm -rf /alpine-builds
+
+# Python / ansible addon work
+# update pip
+pip install --upgrade pip
+# install all python packages
+pip install -r /requirements.txt
+
+# Terraform
+#Installing Terraform binary
+wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip 
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip 
+rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip 
+mv terraform /usr/bin/
+# Adding Terraform Provider Execute addon
+wget https://github.com/samsung-cnct/terraform-provider-execute/releases/download/${TF_PROVIDEREXECUTE_VERSION}/terraform-provider-execute_linux_amd64.tar.gz 
+    tar -zxvf terraform-provider-execute_linux_amd64.tar.gz 
+rm terraform-provider-execute_linux_amd64.tar.gz 
+mv terraform-provider-execute /usr/bin/
+# Adding Terraform CoreOS Box addon
+wget https://github.com/samsung-cnct/terraform-provider-coreosbox/releases/download/${TF_COREOSBOX_VERSION}/terraform-provider-coreosbox_linux_amd64.tar.gz 
+    tar -zxvf terraform-provider-coreosbox_linux_amd64.tar.gz 
+rm terraform-provider-coreosbox_linux_amd64.tar.gz 
+mv terraform-provider-coreosbox /usr/bin/
+# Adding Terraform Distro Image Selector addon
+wget https://github.com/samsung-cnct/terraform-provider-distroimage/releases/download/${TF_DISTROIMAGE_VERSION}/terraform-provider-distroimage_linux_amd64.tar.gz 
+    tar -zxvf terraform-provider-distroimage_linux_amd64.tar.gz 
+rm terraform-provider-distroimage_linux_amd64.tar.gz 
+mv terraform-provider-distro /usr/bin/
+
+# Kubernetes
+# Creating path for helm and kubectl executables
+mkdir -p /opt/cnct/kubernetes/v1.4/bin /opt/cnct/kubernetes/v1.5/bin /opt/cnct/kubernetes/v1.6/bin
+ln -s /opt/cnct/kubernetes/$LATEST /opt/cnct/kubernetes/latest
+
+# Kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_4}/bin/linux/amd64/kubectl 
+chmod a+x kubectl 
+mv kubectl /opt/cnct/kubernetes/v1.4/bin
+wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_5}/bin/linux/amd64/kubectl 
+chmod a+x kubectl 
+mv kubectl /opt/cnct/kubernetes/v1.5/bin
+wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_6}/bin/linux/amd64/kubectl 
+chmod a+x kubectl 
+mv kubectl /opt/cnct/kubernetes/v1.6/bin
+ln -s /opt/cnct/kubernetes/v1.4/bin/kubectl /usr/bin/
+
+# Helm
+wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz 
+tar -zxvf helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz 
+mv linux-amd64/helm /opt/cnct/kubernetes/v1.4/bin/helm 
+rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz
+wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz 
+tar -zxvf helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz 
+mv linux-amd64/helm /opt/cnct/kubernetes/v1.5/bin/helm 
+rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz
+wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz 
+tar -zxvf helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz 
+mv linux-amd64/helm /opt/cnct/kubernetes/v1.6/bin/helm 
+rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz
+ln -s /opt/cnct/kubernetes/v1.5/bin/helm /usr/bin/
+
+# Clean up unneeded data
+apk del alpine-sdk mtools mkinitfs kmod squashfs-tools git g++ gcc make musl-dev libc-dev python-dev linux-headers
+rm -rfv ~/.cache
+rm -rfv /var/cache/apk/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ cryptography==1.3.1
 docutils==0.13.1
 ecdsa==0.13
 futures==3.0.5
+gcloud==0.18.3
 jsonref==0.1
 jsonschema==2.5.1
 Jinja2==2.8


### PR DESCRIPTION
The RUNs install a lot of unneeded stuff that is later removed. This
leaves the image very large as those committed layers do not shrink.

This moves all the RUNs into a single shell script that can clean up
after itself - leaving the image much smaller.

Fixes #51

Tested and passed via k2 - https://common-jenkins.kubeme.io/job/K2/view/change-requests/job/PR-482/9/