### PR TITLE
Shrink docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,74 +41,66 @@ RUN     apk update && apk add --no-cache openssl python bash wget py-pip py-cffi
 
 # Python / ansible addon work
 ADD     requirements.txt /requirements.txt
-        # update pip
-RUN     pip install --upgrade pip
-        # install all python packages
-RUN     pip install -r /requirements.txt
+ADD     imagerun.sh /imagerun.sh
+ADD     gcloud_tree.py /gcloud_tree.py
+
+# wget
+RUN     apk update && apk add --no-cache ca-certificates wget &&  rm -rfv /var/cache/apk/*
 
 # Terraform
+    # Installing Terraform binary
+RUN     wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+        unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+        rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+        mv terraform /usr/bin/
 
-        #Installing Terraform binary
-RUN     curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-	    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && mv terraform /usr/bin/
-
-	    # Adding Terraform Provider Execute addon
+    # Adding Terraform Provider Execute addon
 RUN     wget https://github.com/samsung-cnct/terraform-provider-execute/releases/download/${TF_PROVIDEREXECUTE_VERSION}/terraform-provider-execute_linux_amd64.tar.gz && \
-        tar -zxvf terraform-provider-execute_linux_amd64.tar.gz && rm terraform-provider-execute_linux_amd64.tar.gz && mv terraform-provider-execute /usr/bin/
+        tar -zxvf terraform-provider-execute_linux_amd64.tar.gz && \
+        rm terraform-provider-execute_linux_amd64.tar.gz && \
+        mv terraform-provider-execute /usr/bin/
 
-	    # Adding Terraform CoreOS Box addon
-RUN 	wget https://github.com/samsung-cnct/terraform-provider-coreosbox/releases/download/${TF_COREOSBOX_VERSION}/terraform-provider-coreosbox_linux_amd64.tar.gz && \
-	    tar -zxvf terraform-provider-coreosbox_linux_amd64.tar.gz && rm terraform-provider-coreosbox_linux_amd64.tar.gz && mv terraform-provider-coreosbox /usr/bin/
-
-	    # Adding Terraform Distro Image Selector addon
-RUN 	wget https://github.com/samsung-cnct/terraform-provider-distroimage/releases/download/${TF_DISTROIMAGE_VERSION}/terraform-provider-distroimage_linux_amd64.tar.gz && \
-	    tar -zxvf terraform-provider-distroimage_linux_amd64.tar.gz && rm terraform-provider-distroimage_linux_amd64.tar.gz && mv terraform-provider-distro /usr/bin/
-
-# AWS work
-
-        # Adding AWS CLI
-RUN     pip install awscli
-
-# Google cloud work
-RUN     wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip && \
-        unzip google-cloud-sdk.zip && \
-        rm google-cloud-sdk.zip
-RUN     google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
-
-
-        # Disable updater check for the whole installation.
-        # Users won't be bugged with notifications to update to the latest version of gcloud.
-RUN     google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
-
-        # Disable updater completely.
-        # Running `gcloud components update` doesn't really do anything in a union FS.
-        # Changes are lost on a subsequent run.
-RUN     sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
-
-        # Adding Kubernetes
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /usr/bin
-
-         # Adding Helm
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz && mv linux-amd64/helm /usr/bin/ && rm -rf linux-amd64 helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
+    # Adding Terraform CoreOS Box addon
+RUN     wget https://github.com/samsung-cnct/terraform-provider-coreosbox/releases/download/${TF_COREOSBOX_VERSION}/terraform-provider-coreosbox_linux_amd64.tar.gz && \
+        tar -zxvf terraform-provider-coreosbox_linux_amd64.tar.gz && \
+        rm terraform-provider-coreosbox_linux_amd64.tar.gz && \
+        mv terraform-provider-coreosbox /usr/bin/
+    # Adding Terraform Distro Image Selector addon
+RUN     wget https://github.com/samsung-cnct/terraform-provider-distroimage/releases/download/${TF_DISTROIMAGE_VERSION}/terraform-provider-distroimage_linux_amd64.tar.gz && \
+        tar -zxvf terraform-provider-distroimage_linux_amd64.tar.gz && \
+        rm terraform-provider-distroimage_linux_amd64.tar.gz && \
+        mv terraform-provider-distro /usr/bin/
 
 # Kubernetes
+    # Creating path for helm and kubectl executables
+RUN     mkdir -p /opt/cnct/kubernetes/v1.4/bin \
+                 /opt/cnct/kubernetes/v1.5/bin \
+                 /opt/cnct/kubernetes/v1.6/bin && \
+        ln -s /opt/cnct/kubernetes/$LATEST /opt/cnct/kubernetes/latest
 
-        # Creating path for helm and kubectl executables
-RUN     mkdir -p /opt/cnct/kubernetes/v1.4/bin
-RUN     mkdir -p /opt/cnct/kubernetes/v1.5/bin
-RUN     mkdir -p /opt/cnct/kubernetes/v1.6/bin
-RUN     ln -s /opt/cnct/kubernetes/$LATEST /opt/cnct/kubernetes/latest
+# Kubectl
+RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_4}/bin/linux/amd64/kubectl && \
+        chmod a+x kubectl && \
+        mv kubectl /opt/cnct/kubernetes/v1.4/bin && \
+        ln -s /opt/cnct/kubernetes/v1.4/bin/kubectl /usr/bin/
+RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_5}/bin/linux/amd64/kubectl && \
+        chmod a+x kubectl && \
+        mv kubectl /opt/cnct/kubernetes/v1.5/bin
+RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_6}/bin/linux/amd64/kubectl && \
+        chmod a+x kubectl && \
+        mv kubectl /opt/cnct/kubernetes/v1.6/bin
 
-        # Helm versioning
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz && mv linux-amd64/helm /opt/cnct/kubernetes/v1.4/bin/helm && rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz && mv linux-amd64/helm /opt/cnct/kubernetes/v1.5/bin/helm && rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz
-RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz && \
-        tar -zxvf helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz && mv linux-amd64/helm /opt/cnct/kubernetes/v1.6/bin/helm && rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz
-
-        # Kubectl versioning
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_4}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /opt/cnct/kubernetes/v1.4/bin
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_5}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /opt/cnct/kubernetes/v1.5/bin
-RUN     wget https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION_1_6}/bin/linux/amd64/kubectl && chmod a+x kubectl && mv kubectl /opt/cnct/kubernetes/v1.6/bin
+# Helm
+RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz  && \
+        tar -zxvf helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz  && \
+        mv linux-amd64/helm /opt/cnct/kubernetes/v1.4/bin/helm  && \
+        rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_4}-linux-amd64.tar.gz
+RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz  && \
+        tar -zxvf helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz  && \
+        mv linux-amd64/helm /opt/cnct/kubernetes/v1.5/bin/helm  && \
+        rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_5}-linux-amd64.tar.gz && \
+        ln -s /opt/cnct/kubernetes/v1.5/bin/helm /usr/bin/
+RUN     wget http://storage.googleapis.com/kubernetes-helm/helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz  && \
+        tar -zxvf helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz  && \
+        mv linux-amd64/helm /opt/cnct/kubernetes/v1.6/bin/helm  && \
+        rm -rf linux-amd64 helm-${K8S_HELM_VERSION_1_6}-linux-amd64.tar.gz

--- a/gcloud_tree.py
+++ b/gcloud_tree.py
@@ -1,0 +1,10 @@
+#!/bin/env python
+
+# The original gcloud_tree is generated with the following command:
+#     gcloud meta list-gcloud --format=json | python -c "import json;import sys;data = json.load(sys.stdin);print 'gcloud_tree =', data" >> gcloud_tree.py
+# This leads to creating a very inefficient 19MB data file. By downloading 
+# and storing the same json data, this method keeps it under 25K.
+
+import gzip
+import json
+gcloud_tree = json.load(gzip.open("/google-cloud-sdk/gcloud_tree.json.gz"))

--- a/imagerun.sh
+++ b/imagerun.sh
@@ -1,0 +1,67 @@
+#!/bin/sh -e
+set -o pipefail
+
+# Prepping Alpine
+# Adding baseline alpine packages
+apk update 
+apk add --no-cache  \
+    openssl \
+    ca-certificates \
+    python \
+    bash \
+    py-pip \
+    py-cffi \
+    py-cryptography \
+    unzip \
+    zip \
+    python-dev \
+    gcc \
+    linux-headers \
+    musl-dev \
+    g++
+/alpine-builds/build-docker.sh 
+rm -rf /alpine-builds
+
+# Python / ansible addon work
+# update pip
+pip install --upgrade pip
+# install all python packages
+pip install -r /requirements.txt
+
+
+# Google cloud work
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip
+unzip google-cloud-sdk.zip
+rm google-cloud-sdk.zip
+google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
+# Disable updater check for the whole installation.
+# Users won't be bugged with notifications to update to the latest version of gcloud.
+google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
+# Disable updater completely.
+# Running `gcloud components update` doesn't really do anything in a union FS.
+# Changes are lost on a subsequent run.
+sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
+
+rm -rf /google-cloud-sdk/.install \
+       /google-cloud-sdk/platform/gsutil/third_party/boto \
+       /google-cloud-sdk/platform/gsutil/third_party/httplib2 \
+       /google-cloud-sdk/platform/gsutil/third_party/oauth2client \
+       /google-cloud-sdk/platform/gsutil/third_party/pyasn1 \
+       /google-cloud-sdk/platform/gsutil/third_party/pyasn1_modules \
+       /google-cloud-sdk/platform/gsutil/third_party/rsa 
+ln -s /usr/lib/python2.7/site-packages/boto \
+      /usr/lib/python2.7/site-packages/httplib2 \
+      /usr/lib/python2.7/site-packages/oauth2client \
+      /usr/lib/python2.7/site-packages/pyasn1 \
+      /usr/lib/python2.7/site-packages/pyasn1_modules \
+      /usr/lib/python2.7/site-packages/rsa \
+      /google-cloud-sdk/platform/gsutil/third_party/
+
+# Remove a 19MB data file and replace it with a 250KB one
+google-cloud-sdk/bin/gcloud meta list-gcloud --format=json | gzip > /google-cloud-sdk/gcloud_tree.json.gz
+mv /gcloud_tree.py /google-cloud-sdk/lib/googlecloudsdk/command_lib/gcloud_tree.py
+
+# Clean up unneeded data
+apk del alpine-sdk mtools mkinitfs kmod squashfs-tools git g++ gcc make musl-dev libc-dev python-dev linux-headers
+rm -rfv ~/.cache
+rm -rfv /var/cache/apk/*


### PR DESCRIPTION
Move the compiler built stuff out of the Dockerfile and into a shell script for ease of cleaning.

Shrink the size of the installed google sdk by half

This, again, addresses issue #51.

Tested via k2 https://common-jenkins.kubeme.io/job/K2/view/change-requests/job/PR-482/10/ where the only change to k2 was to use the version of this image I pushed to dockerhub.
https://github.com/samsung-cnct/k2/pull/482/files
https://hub.docker.com/r/joejulian/k2-tools-test