### PR TITLE
Add helm registry plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ ENV     K8S_HELM_VERSION_LATEST=$K8S_HELM_VERSION_1_6
 ENV     GOPATH /go
 ENV     GO15VENDOREXPERIMENT 1
 
+ENV     HELM_HOME=/etc/helm
+
 # Prepping Alpine
 
 ADD     /alpine-builds /alpine-builds
@@ -85,7 +87,8 @@ RUN     sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /go
     # Creating path for helm and kubectl executables
 RUN     mkdir -p /opt/cnct/kubernetes/v1.4/bin \
                  /opt/cnct/kubernetes/v1.5/bin \
-                 /opt/cnct/kubernetes/v1.6/bin && \
+                 /opt/cnct/kubernetes/v1.6/bin \
+                 /etc/helm/plugins/cnr && \
         ln -s /opt/cnct/kubernetes/$LATEST /opt/cnct/kubernetes/latest
 
 # Kubectl
@@ -121,3 +124,7 @@ ADD     imagerun.sh /imagerun.sh
 ADD     gcloud_tree.py /gcloud_tree.py
 
 RUN     /imagerun.sh
+RUN     ln -s /usr/lib/python2.7/site-packages/cnrclient/commands/plugins/helm/cnr.sh \
+            /usr/lib/python2.7/site-packages/cnrclient/commands/plugins/helm/plugin.yaml \
+            /usr/bin/cnr \
+            /etc/helm/plugins/cnr

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV     GOPATH /go
 ENV     GO15VENDOREXPERIMENT 1
 
 ENV     HELM_HOME=/etc/helm
+ENV     HELM_PLUGIN=/etc/helm/plugins
 
 # Prepping Alpine
 
@@ -88,7 +89,7 @@ RUN     sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /go
 RUN     mkdir -p /opt/cnct/kubernetes/v1.4/bin \
                  /opt/cnct/kubernetes/v1.5/bin \
                  /opt/cnct/kubernetes/v1.6/bin \
-                 /etc/helm/plugins/cnr && \
+                 /etc/helm/plugins/appr && \
         ln -s /opt/cnct/kubernetes/$LATEST /opt/cnct/kubernetes/latest
 
 # Kubectl
@@ -124,7 +125,8 @@ ADD     imagerun.sh /imagerun.sh
 ADD     gcloud_tree.py /gcloud_tree.py
 
 RUN     /imagerun.sh
-RUN     ln -s /usr/lib/python2.7/site-packages/cnrclient/commands/plugins/helm/cnr.sh \
-            /usr/lib/python2.7/site-packages/cnrclient/commands/plugins/helm/plugin.yaml \
-            /usr/bin/cnr \
-            /etc/helm/plugins/cnr
+RUN     ln -s /usr/lib/python2.7/site-packages/appr/commands/plugins/helm/cnr.sh \
+            /etc/helm/plugins/appr/appr.sh     
+RUN     ln -s /usr/lib/python2.7/site-packages/appr/commands/plugins/helm/plugin.yaml \
+            /usr/bin/appr \
+            /etc/helm/plugins/appr/

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ semver==2.7.7
 s3transfer==0.1.10
 six==1.10.0
 
-https://github.com/app-registry/appr-cli/archive/v0.4.1.tar.gz
+https://github.com/app-registry/appr/archive/v0.5.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ rsa==3.4.2
 semver==2.7.7
 s3transfer==0.1.10
 six==1.10.0
+
+https://github.com/app-registry/appr-cli/archive/v0.4.1.tar.gz


### PR DESCRIPTION
This plugin allows the use of the quay.io application registry (or a
private registry) for helm charts.