### PR TITLE
remove k2-crash-app in path.  put application in /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,5 @@ RUN     ln -s /usr/lib/python2.7/site-packages/appr/commands/plugins/helm/plugin
 # Crash application
 RUN     wget https://github.com/samsung-cnct/k2-crash-application/releases/download/0.1.0/k2-crash-application_0.1.0_linux_amd64.tar.gz  && \
         tar -zxvf k2-crash-application_0.1.0_linux_amd64.tar.gz  && \
-        mkdir /usr/bin/k2-crash-app && \
-        mv k2-crash-application /usr/bin/k2-crash-app/k2-crash-application && \
+        mv k2-crash-application /usr/bin/k2-crash-application && \
         rm -rf k2-crash-application_0.1.0_linux_amd64.tar.gz


### PR DESCRIPTION
Missed this in the update.   Subdirectory k2-crash-app should  not be in the path.  
The application should reside in /usr/bin directly so `which` works correctly.