### PR TITLE
changes to support a fully functional GKE k2 provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV     TF_DISTROIMAGE_VERSION=v0.0.1
 ENV     TF_PROVIDEREXECUTE_VERSION=v0.0.4
 
 ENV     GCLOUD_SDK_VERSION=128.0.0
-ENV     GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+ENV     GCLOUD_FILE_NAME=google-cloud-sdk-${GCLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+ENV     GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILE_NAME}
 ENV     CLOUDSDK_PYTHON_SITEPACKAGES 1
         # google cloud kubectl is superceeded by downloaded kubectl
 ENV     PATH $PATH:/google-cloud-sdk/bin
@@ -71,9 +72,9 @@ RUN 	wget https://github.com/samsung-cnct/terraform-provider-distroimage/release
 RUN     pip install awscli
 
 # Google cloud work
-RUN     wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip && \
-        unzip google-cloud-sdk.zip && \
-        rm google-cloud-sdk.zip
+RUN     wget ${GCLOUD_SDK_URL} && \
+        tar -xf ${GCLOUD_FILE_NAME} && \
+        rm ${GCLOUD_FILE_NAME}
 RUN     google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
 
 

--- a/imagerun.sh
+++ b/imagerun.sh
@@ -29,39 +29,41 @@ pip install --upgrade pip
 pip install -r /requirements.txt
 
 
-# Google cloud work
-wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip
-unzip -o google-cloud-sdk.zip
-rm google-cloud-sdk.zip
-google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
-# Disable updater check for the whole installation.
-# Users won't be bugged with notifications to update to the latest version of gcloud.
-google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
-# Disable updater completely.
-# Running `gcloud components update` doesn't really do anything in a union FS.
-# Changes are lost on a subsequent run.
-sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
-
-rm -rf /google-cloud-sdk/.install \
-       /google-cloud-sdk/platform/gsutil/third_party/boto \
-       /google-cloud-sdk/platform/gsutil/third_party/httplib2 \
-       /google-cloud-sdk/platform/gsutil/third_party/oauth2client \
-       /google-cloud-sdk/platform/gsutil/third_party/pyasn1 \
-       /google-cloud-sdk/platform/gsutil/third_party/pyasn1_modules \
-       /google-cloud-sdk/platform/gsutil/third_party/rsa 
-ln -s /usr/lib/python2.7/site-packages/boto \
-      /usr/lib/python2.7/site-packages/httplib2 \
-      /usr/lib/python2.7/site-packages/oauth2client \
-      /usr/lib/python2.7/site-packages/pyasn1 \
-      /usr/lib/python2.7/site-packages/pyasn1_modules \
-      /usr/lib/python2.7/site-packages/rsa \
-      /google-cloud-sdk/platform/gsutil/third_party/
-
-# Remove a 19MB data file and replace it with a 250KB one
-google-cloud-sdk/bin/gcloud meta list-gcloud --format=json | gzip > /google-cloud-sdk/gcloud_tree.json.gz
-mv /gcloud_tree.py /google-cloud-sdk/lib/googlecloudsdk/command_lib/gcloud_tree.py
-
-# Clean up unneeded data
-apk del alpine-sdk libffi-dev openssl-dev mtools mkinitfs kmod squashfs-tools git g++ gcc make musl-dev libc-dev python-dev linux-headers
-rm -rfv ~/.cache
-rm -rfv /var/cache/apk/*
+##  DISABLED BY COFFEEPAC
+## Google cloud work
+#wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip
+#unzip -o google-cloud-sdk.zip
+#rm google-cloud-sdk.zip
+#google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
+## Disable updater check for the whole installation.
+## Users won't be bugged with notifications to update to the latest version of gcloud.
+#google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
+## Disable updater completely.
+## Running `gcloud components update` doesn't really do anything in a union FS.
+## Changes are lost on a subsequent run.
+#sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
+#
+#rm -rf /google-cloud-sdk/.install \
+#       /google-cloud-sdk/platform/gsutil/third_party/boto \
+#       /google-cloud-sdk/platform/gsutil/third_party/httplib2 \
+#       /google-cloud-sdk/platform/gsutil/third_party/oauth2client \
+#       /google-cloud-sdk/platform/gsutil/third_party/pyasn1 \
+#       /google-cloud-sdk/platform/gsutil/third_party/pyasn1_modules \
+#       /google-cloud-sdk/platform/gsutil/third_party/rsa 
+#ln -s /usr/lib/python2.7/site-packages/boto \
+#      /usr/lib/python2.7/site-packages/httplib2 \
+#      /usr/lib/python2.7/site-packages/oauth2client \
+#      /usr/lib/python2.7/site-packages/pyasn1 \
+#      /usr/lib/python2.7/site-packages/pyasn1_modules \
+#      /usr/lib/python2.7/site-packages/rsa \
+#      /google-cloud-sdk/platform/gsutil/third_party/
+#
+## Remove a 19MB data file and replace it with a 250KB one
+#google-cloud-sdk/bin/gcloud meta list-gcloud --format=json | gzip > /google-cloud-sdk/gcloud_tree.json.gz
+#mv /gcloud_tree.py /google-cloud-sdk/lib/googlecloudsdk/command_lib/gcloud_tree.py
+#
+## Clean up unneeded data
+#apk del alpine-sdk libffi-dev openssl-dev mtools mkinitfs kmod squashfs-tools git g++ gcc make musl-dev libc-dev python-dev linux-headers
+#rm -rfv ~/.cache
+#rm -rfv /var/cache/apk/*
+#


### PR DESCRIPTION
changes made:
- use pinned version of gcloud utils
- stop a lot of the thinning down, it was causing compile problems

this fixes samsung-cnct/k2#616