### PR TITLE
change how we install app registry plugin for helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ ENV     K8S_VERSION_1_5=v1.5.7
 ENV     K8S_VERSION_1_6=v1.6.8
 ENV     K8S_VERSION_1_7=v1.7.4
 
-
-
 ENV     K8S_HELM_VERSION_1_5=v2.3.1
 ENV     K8S_HELM_VERSION_1_6=v2.5.1
 ENV     K8S_HELM_VERSION_1_7=v2.6.0
@@ -39,6 +37,8 @@ ENV     GO15VENDOREXPERIMENT 1
 
 ENV     HELM_HOME=/etc/helm
 ENV     HELM_PLUGIN=/etc/helm/plugins
+ENV     APP_REGISTRY_PLUGIN_RELEASE=v0.7.0
+ENV     APP_REGISTRY_URL=https://github.com/app-registry/appr-helm-plugin/releases/download/${APP_REGISTRY_PLUGIN_RELEASE}/helm-registry_linux.tar.gz
 
 # Alpine
 
@@ -143,7 +143,8 @@ RUN     wget -q ${GCLOUD_SDK_URL} && \
         gcloud config set metrics/environment github_docker_image
 
 # Install the help app registry plugin
-RUN     appr plugins install helm && rm /etc/helm/plugins/*.gz
+RUN     mkdir -p /etc/helm/plugins/appr && \
+        cd ${HELM_PLUGIN} && wget ${APP_REGISTRY_URL} -O - | tar -zxv
 
 # Crash application
 RUN     wget -q https://github.com/samsung-cnct/k2-crash-application/releases/download/0.1.0/k2-crash-application_0.1.0_linux_amd64.tar.gz && \

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -26,5 +26,3 @@ rsa==3.4.2
 semver==2.7.7
 s3transfer==0.1.10
 six==1.10.0
-
-https://github.com/app-registry/appr/archive/v0.6.1.tar.gz


### PR DESCRIPTION
using the `appr` binary broke with version 0.7.0 of the helm plugin
because the helm plugin now has a windows client so the target URL
changed.

Fixes: #127 